### PR TITLE
fix: force set extension

### DIFF
--- a/concepcy/__init__.py
+++ b/concepcy/__init__.py
@@ -67,8 +67,8 @@ class ConcepCyComponent:
         self.parser = ConceptnetParser(relations_of_interest, as_dict, filter_edge_fct)
 
         for relation in relations_of_interest:
-            Doc.set_extension(relation.lower(), default=defaultdict(list))
-            Token.set_extension(relation.lower(), default=[])
+            Doc.set_extension(relation.lower(), default=defaultdict(list), force=True)
+            Token.set_extension(relation.lower(), default=[], force=True)
 
     def make_requests(self, words: List[str]) -> List[Dict]:
         """


### PR DESCRIPTION
This PR aims at simply adding the `force=True` parameter when setting extension for both `Doc` and `Token` objects.
That way one will not run into an issue when adding *concepCy* to a SpaCy pipeline multiple times.